### PR TITLE
Update syntax to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "preview": false,
   "private": true,
   "syntax": {
-    "version": "0.3.0"
+    "version": "0.4.3"
   },
   "engines": {
     "vscode": "^1.41.0"


### PR DESCRIPTION
This commit updates the syntax version to [0.4.3](https://github.com/hashicorp/syntax/releases/tag/v0.4.3) which includes a fix for imports which include a forward slash "/"