### PR TITLE
Prepare for 0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ENHANCEMENT:
 
-* Update syntax to latest version ([#28](https://github.com/hashicorp/vscode-sentinel/pull/28))
+* Update syntax to version to [0.4.3](https://github.com/hashicorp/syntax/releases/tag/v0.4.3) which includes a fix for imports which include a forward slash "/" ([#28](https://github.com/hashicorp/vscode-sentinel/pull/28))
 
 INTERNAL:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [0.3.0] (2023-12-06)
+
+ENHANCEMENT:
+
+* Update syntax to latest version ([#28](https://github.com/hashicorp/vscode-sentinel/pull/28))
+
+INTERNAL:
+
+* Add Copyright and License Headers ([#25](https://github.com/hashicorp/vscode-sentinel/pull/25))
+* Automated trusted workflow pinning ([#27](https://github.com/hashicorp/vscode-sentinel/pull/27))
+
 ## [0.2.2] (2022-11-14)
 
 ENHANCEMENTS:
@@ -42,12 +53,9 @@ INTERNAL:
 
 **Full Changelog**: https://github.com/hashicorp/vscode-sentinel/commits/v0.1.0
 
-## 0.3.0 (2020-07-16)
-
-- Initial release
-
 <!-- Links to tag comparisons -->
-[Unreleased]: https://github.com/hashicorp/vscode-sentinel/compare/v0.2.0...main
+[Unreleased]: https://github.com/hashicorp/vscode-sentinel/compare/v0.3.0...main
+[0.3.0]: https://github.com/hashicorp/vscode-sentinel/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/hashicorp/vscode-sentinel/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/hashicorp/vscode-sentinel/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/hashicorp/vscode-sentinel/compare/v0.1.0...v0.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sentinel",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sentinel",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "got": "^11.8.5",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "HashiCorp Sentinel",
   "publisher": "hashicorp",
   "description": "Syntax highlighting for HashiCorp Sentinel",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "license": "MPL-2.0",
   "preview": false,
   "private": true,


### PR DESCRIPTION
One thing to note is that I actually attempted to cut a release earlier (before understanding fully how it's meant to be done 🙈 ) and ran into an issue with a newer `got` version.

 - I merged https://github.com/hashicorp/vscode-sentinel/pull/24 in the hope of addressing some dependabot alerts before the release
 - That then [broke](https://github.com/hashicorp/vscode-sentinel/actions/runs/7098953547/job/19321961983#step:7:21) `npm run download:syntax` because all later versions of `got` have some compatibility issues with the way we use the library.
 - I looked briefly into what would it take to make us compatible again but I was left even more puzzled after reading through https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
   - It seems to imply that anything wanting to use the library needs to become a library too?? (implied from requiring `"type": "module"` in `package.json` and other related changes) I don't quite understand the full implications but it seems odd to me since we are not publishing reusable library but VS Code extension.
 - That has led me to revert the bumps subsequently in https://github.com/hashicorp/vscode-sentinel/commit/86823969fc535e08ef68e5d0a1016c8203fddf7e

I would appreciate some more educated opinions on the above ^

My short-term take is that because we don't use `got` at runtime but rather build time, it's not as important to keep it updated since any vulnerabilities have far more limited impact. I assume that we will need to upgrade it eventually though.